### PR TITLE
Adds patch to router.

### DIFF
--- a/Source/Localhost/LocalhostRouter.swift
+++ b/Source/Localhost/LocalhostRouter.swift
@@ -15,6 +15,9 @@ public protocol LocalhostRouter {
     func post(_ path: String, routeBlock: @escaping ((URLRequest) -> LocalhostServerResponse?))
     func delete(_ path: String, routeBlock: @escaping ((URLRequest) -> LocalhostServerResponse?))
     func put(_ path: String, routeBlock: @escaping ((URLRequest) -> LocalhostServerResponse?))
+    func patch(_ path: String, routeBlock: @escaping ((URLRequest) -> LocalhostServerResponse?))
+    func options(_ path: String, routeBlock: @escaping ((URLRequest) -> LocalhostServerResponse?))
+    func head(_ path: String, routeBlock: @escaping ((URLRequest) -> LocalhostServerResponse?))
     
     func startListening()
     func stopListening()

--- a/Source/Localhost/LocalhostServer.swift
+++ b/Source/Localhost/LocalhostServer.swift
@@ -47,6 +47,15 @@ extension LocalhostServer: LocalhostRouter {
         })
     }
     
+    public func patch(_ path: String, routeBlock: @escaping ((URLRequest) -> LocalhostServerResponse?)) {
+        self.server.add(path, block: {  [weak self] (req, res, next) in
+            self?.handleRoute(httpMethod: "PATCH",
+                              routeBlock: routeBlock,
+                              crRequest: req,
+                              crResponse: res)
+            }, recursive: false, method: .patch)
+    }
+    
     public func head(_ path: String, routeBlock: @escaping ((URLRequest) -> LocalhostServerResponse?)) {
         self.server.head(path, block: {  [weak self] (req, res, next) in
             self?.handleRoute(httpMethod: "HEAD",


### PR DESCRIPTION
There are methods on router for all the HTTP methods but no for patch.
I added it to the concrete [Router/Server](https://github.com/llinardos/SwiftLocalhost/blob/update-LocalhostServer/Source/Localhost/LocalhostServer.swift) and to the [Router Protocol](https://github.com/llinardos/SwiftLocalhost/blob/update-LocalhostServer/Source/Localhost/LocalhostRouter.swift).

Criollo also misses the patch. I send a PR to them today. Once merged we should change how the patch call is implemented [here](https://github.com/thecatalinstan/Criollo/pull/42).