### PR TITLE
Adding Capability for multiple responses per path route

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,21 @@ self.localhostServer.get("/3/movie/popular", routeBlock: { request in
 })
 
 ```
+
+You can queue up mock responses for the same route path. Mock responses will be returned in FIFO order. Used responses will be removed from the queue unless there is only 1 response left in the queue.
+
+```swift
+
+var dataResponse1, dataResponse2, dataResponse3: Data!
+
+self.localhostServer.route(method: .GET,
+                           path: "/3/movie/popular",
+                           responseData: dataResponse1)
+self.localhostServer.route(method: .GET,
+                           path: "/3/movie/popular",
+                           responseData: dataResponse2)
+self.localhostServer.route(method: .GET,
+                           path: "/3/movie/popular",
+                           responseData: dataResponse2)
+```
+

--- a/Source/Localhost/LocalhostRouter.swift
+++ b/Source/Localhost/LocalhostRouter.swift
@@ -16,8 +16,8 @@ public protocol LocalhostRouter {
     func delete(_ path: String, routeBlock: @escaping ((URLRequest) -> LocalhostServerResponse?))
     func put(_ path: String, routeBlock: @escaping ((URLRequest) -> LocalhostServerResponse?))
     func patch(_ path: String, routeBlock: @escaping ((URLRequest) -> LocalhostServerResponse?))
-    func options(_ path: String, routeBlock: @escaping ((URLRequest) -> LocalhostServerResponse?))
     func head(_ path: String, routeBlock: @escaping ((URLRequest) -> LocalhostServerResponse?))
+    func options(_ path: String, routeBlock: @escaping ((URLRequest) -> LocalhostServerResponse?))
     
     func startListening()
     func stopListening()

--- a/SwiftLocalhost.podspec
+++ b/SwiftLocalhost.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "SwiftLocalhost"
-  s.version          = "0.0.7"
+  s.version          = "0.0.8"
   s.swift_version    = '4.2'
   s.summary          = "Swift Localhost Server for your testing needs"
   s.description      = <<-DESC


### PR DESCRIPTION
- Introducing  `var overlayingRoutes` that captures an ordered array of responses for each path-route key.
- This PR basically adds an extra layer on top of Criollo to handle multiple responses per path-route